### PR TITLE
fixed search box overlapping with google maps elements

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -32,3 +32,7 @@ html, body {
     color: #eee;
     font-size: 56pt !important;
 }
+
+.form-control {
+    width: 80% !important;
+}


### PR DESCRIPTION
search box was overlapping with google maps default controls due to a bootstrap class.  overrode the width: 100% in our own css file.