### PR TITLE
prevent duplicate markers from being created on the Google Map

### DIFF
--- a/assets/javascript/hardcoded.js
+++ b/assets/javascript/hardcoded.js
@@ -740,11 +740,16 @@ $(document).on("click", ".park-button", function(event) {
 
 	map.setZoom(10);
 
-    var marker = new google.maps.Marker({
+	markers.forEach(function(marker) {
+		marker.setMap(null);
+	});
+	markers = [];
+
+    markers.push(new google.maps.Marker({
         position: {lat: 36.505, lng: -117.079},
         map: map,
         title: 'Death Valley National Park'
-	});
+	}));
 
 });
 
@@ -757,11 +762,16 @@ $(document).on("click", ".attraction", function(event) {
 	
 	map.setZoom(15);
 
-    var marker = new google.maps.Marker({
+	markers.forEach(function(marker) {
+		marker.setMap(null);
+	});
+	markers = [];
+
+    markers.push(new google.maps.Marker({
         position: {lat: $(this).data("lat"), lng: $(this).data("lng")},
         map: map,
         title: $(this).data("name")
-	});
+	}));
 
 });
 

--- a/assets/javascript/script.js
+++ b/assets/javascript/script.js
@@ -121,11 +121,16 @@ $(document).on("click", ".park-button", function(event) {
     ));
     map.setZoom(10);
 
-    var marker = new google.maps.Marker({
+    markers.forEach(function(marker) {
+        marker.setMap(null);
+    });
+    markers = [];
+
+    markers.push(new google.maps.Marker({
         position: {lat: $(this).data("lat"), lng: $(this).data("lng")},
         map: map,
         title: $(this).data("park")
-    });
+    }));
 
 });
 
@@ -139,11 +144,16 @@ $(document).on("click", ".attraction", function(event) {
         ));
     map.setZoom(15);
 
-    var marker = new google.maps.Marker({
+    markers.forEach(function(marker) {
+        marker.setMap(null);
+    });
+    markers = [];
+
+    markers.push(new google.maps.Marker({
         position: {lat: $(this).data("lat"), lng: $(this).data("lng")},
         map: map,
         title: $(this).data("name")
-    });
+    }));
 });
 
 var renderWeather = function() {

--- a/hardcoded.html
+++ b/hardcoded.html
@@ -74,6 +74,7 @@
       
       <script>
         var map;
+        var markers = [];
           function initAutocomplete() {
               map = new google.maps.Map(document.getElementById('map'), {
               center: {lat: 37.872, lng: -122.271},
@@ -91,7 +92,6 @@
               searchBox.setBounds(map.getBounds());
               });
 
-              var markers = [];
               // Listen for the event fired when the user selects a prediction and retrieve
               // more details for that place.
               searchBox.addListener('places_changed', function() {

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
       
       <script>
         var map;
+        var markers = [];
           function initAutocomplete() {
               map = new google.maps.Map(document.getElementById('map'), {
               center: {lat: 37.872, lng: -122.271},
@@ -92,7 +93,6 @@
               searchBox.setBounds(map.getBounds());
               });
 
-              var markers = [];
               // Listen for the event fired when the user selects a prediction and retrieve
               // more details for that place.
               searchBox.addListener('places_changed', function() {


### PR DESCRIPTION
Made it so that clicking on cards no longer creates additional markers on the map.  Instead, the previous marker is removed before the new marker is created.